### PR TITLE
Removing multiple unlike from one user on a post

### DIFF
--- a/routes/postRoutes.js
+++ b/routes/postRoutes.js
@@ -160,28 +160,33 @@ exports.likePost = (req, res) => {
             if (err) return res.status(422).json({ error: err });
             else return res.status(201).json(result);
           });
-    
         }
       }
     }
   );
- 
 };
 
 exports.unlikePost = (req, res) => {
   Like.findOneAndDelete({ postId: req.body.postId, likedBy: req.user._id })
-    .then(() => {
-      Post.findByIdAndUpdate(
-        req.body.postId,
-        {
-          $pull: { likes: req.user._id },
-          $inc: { likeCount: -1 },
-        },
-        { new: true }
-      ).exec((err, result) => {
-        if (err) return res.status(422).json({ error: err });
-        else return res.status(201).json(result);
-      });
+    .then((docs) => {
+      if (docs === null) {
+        Post.findById(req.body.postId).exec((err, result) => {
+          if (err) return res.status(422).json({ error: err });
+          else return res.status(201).json(result);
+        });
+      } else {
+        Post.findByIdAndUpdate(
+          req.body.postId,
+          {
+            $pull: { likes: req.user._id },
+            $inc: { likeCount: -1 },
+          },
+          { new: true }
+        ).exec((err, result) => {
+          if (err) return res.status(422).json({ error: err });
+          else return res.status(201).json(result);
+        });
+      }
     })
     .catch((e) => {
       console.log(e);


### PR DESCRIPTION
### Fixes #23 

### Description
I remove multiple unlike from one user on a post means a user can unlike post only one time on a post. 

**Type of Change:** (Delete irrelevant options)
- Code

**Code/Quality Assurance Only** (Delete irrelevant options)

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance**
- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
