### PR TITLE
Removing multiple unlike from one user on a post

### DIFF
--- a/routes/postRoutes.js
+++ b/routes/postRoutes.js
@@ -408,13 +408,25 @@ exports.likeComment = (req, res) => {
 };
 
 exports.unlikeComment = (req, res) => {
-  Comment.findByIdAndUpdate(
-    req.body.commentId,
-    { $pull: { likes: req.user._id }, $inc: { likeCount: -1 } },
-    { new: true }
-  ).exec((err, result) => {
+  Comment.find({ likes: { $in: req.user._id } }, (err, docs) => {
     if (err) return res.status(422).json({ error: err });
-    return res.status(201).json(result);
+    else {
+      if (docs.length === 1) {
+        Comment.findByIdAndUpdate(
+          req.body.commentId,
+          { $pull: { likes: req.user._id }, $inc: { likeCount: -1 } },
+          { new: true }
+        ).exec((err, result) => {
+          if (err) return res.status(422).json({ error: err });
+          return res.status(201).json(result);
+        });
+      } else {
+        Comment.findById(req.body.commentId).exec((err, result) => {
+          if (err) return res.status(422).json({ error: err });
+          return res.status(201).json(result);
+        });
+      }
+    }
   });
 };
 


### PR DESCRIPTION
### Fixes #33 

### Description
Now a user can unlike  from a particular comment only one time.

**Type of Change:** 
- Code


**Code/Quality Assurance Only**

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
