### PR TITLE
Removing multiple unlike from a user on comment and multiple follows from a user

### DIFF
--- a/routes/postRoutes.js
+++ b/routes/postRoutes.js
@@ -382,29 +382,32 @@ exports.deleteComment = (req, res) => {
     });
 };
 exports.likeComment = (req, res) => {
-  Comment.find({ likes: { $in: req.user._id } }, (err, docs) => {
-    if (err) return res.status(422).json({ error: err });
-    else {
-      if (docs.length === 0) {
-        Comment.findByIdAndUpdate(
-          req.body.commentId,
-          {
-            $push: { likes: req.user._id },
-            $inc: { likeCount: 1 },
-          },
-          { new: true }
-        ).exec((err, result) => {
-          if (err) return res.status(422).json({ error: err });
-          return res.status(201).json(result);
-        });
-      } else {
-        Comment.findById(req.body.commentId).exec((err, result) => {
-          if (err) return res.status(422).json({ error: err });
-          return res.status(201).json(result);
-        });
+  Comment.find(
+    { $and: [{ _id: req.body.commentId }, { likes: { $in: req.user._id } }] },
+    (err, docs) => {
+      if (err) return res.status(422).json({ error: err });
+      else {
+        if (docs.length === 0) {
+          Comment.findByIdAndUpdate(
+            req.body.commentId,
+            {
+              $push: { likes: req.user._id },
+              $inc: { likeCount: 1 },
+            },
+            { new: true }
+          ).exec((err, result) => {
+            if (err) return res.status(422).json({ error: err });
+            return res.status(201).json(result);
+          });
+        } else {
+          Comment.findById(req.body.commentId).exec((err, result) => {
+            if (err) return res.status(422).json({ error: err });
+            return res.status(201).json(result);
+          });
+        }
       }
     }
-  });
+  );
 };
 
 exports.unlikeComment = (req, res) => {

--- a/routes/postRoutes.js
+++ b/routes/postRoutes.js
@@ -382,18 +382,41 @@ exports.deleteComment = (req, res) => {
     });
 };
 exports.likeComment = (req, res) => {
+  Comment.find({ likes: { $in: req.user._id } }, (err, docs) => {
+    if (err) return res.status(422).json({ error: err });
+    else {
+      if (docs.length === 0) {
+        Comment.findByIdAndUpdate(
+          req.body.commentId,
+          {
+            $push: { likes: req.user._id },
+            $inc: { likeCount: 1 },
+          },
+          { new: true }
+        ).exec((err, result) => {
+          if (err) return res.status(422).json({ error: err });
+          return res.status(201).json(result);
+        });
+      } else {
+        Comment.findById(req.body.commentId).exec((err, result) => {
+          if (err) return res.status(422).json({ error: err });
+          return res.status(201).json(result);
+        });
+      }
+    }
+  });
+};
+
+exports.unlikeComment = (req, res) => {
   Comment.find(
     { $and: [{ _id: req.body.commentId }, { likes: { $in: req.user._id } }] },
     (err, docs) => {
       if (err) return res.status(422).json({ error: err });
       else {
-        if (docs.length === 0) {
+        if (docs.length === 1) {
           Comment.findByIdAndUpdate(
             req.body.commentId,
-            {
-              $push: { likes: req.user._id },
-              $inc: { likeCount: 1 },
-            },
+            { $pull: { likes: req.user._id }, $inc: { likeCount: -1 } },
             { new: true }
           ).exec((err, result) => {
             if (err) return res.status(422).json({ error: err });
@@ -408,29 +431,6 @@ exports.likeComment = (req, res) => {
       }
     }
   );
-};
-
-exports.unlikeComment = (req, res) => {
-  Comment.find({ likes: { $in: req.user._id } }, (err, docs) => {
-    if (err) return res.status(422).json({ error: err });
-    else {
-      if (docs.length === 1) {
-        Comment.findByIdAndUpdate(
-          req.body.commentId,
-          { $pull: { likes: req.user._id }, $inc: { likeCount: -1 } },
-          { new: true }
-        ).exec((err, result) => {
-          if (err) return res.status(422).json({ error: err });
-          return res.status(201).json(result);
-        });
-      } else {
-        Comment.findById(req.body.commentId).exec((err, result) => {
-          if (err) return res.status(422).json({ error: err });
-          return res.status(201).json(result);
-        });
-      }
-    }
-  });
 };
 
 exports.getPostComments = (req, res) => {

--- a/routes/postRoutes.js
+++ b/routes/postRoutes.js
@@ -408,13 +408,25 @@ exports.likeComment = (req, res) => {
 };
 
 exports.unlikeComment = (req, res) => {
-  Comment.findByIdAndUpdate(
-    req.body.commentId,
-    { $pull: { likes: req.user._id }, $inc: { likeCount: -1 } },
-    { new: true }
-  ).exec((err, result) => {
+  Comment.find({ likes: { $in: req.user._id } }, (err, docs) => {
     if (err) return res.status(422).json({ error: err });
-    return res.status(201).json(result);
+    else {
+      if (docs.length === 1) {
+        Comment.findByIdAndUpdate(
+          req.body.commentId,
+          { $pull: { likes: req.user._id }, $inc: { likeCount: -1 } },
+          { new: true }
+        ).exec((err, result) => {
+          if (err) return res.status(422).json({ error: err });
+          return res.status(201).json(result);
+        });
+      } else {
+        Comment.findById(req.body.commentId).exec((err, result) => {
+          if (err) return res.status(422).json({ error: err });
+          return res.status(201).json(result);
+        });
+      }
+    }
   });
 };
 


### PR DESCRIPTION
### Fixes #35 

### Description
now  a user can like any comment only one time  and   a user can follow other user only one time while he unfollow that user.

**Type of Change:**
- Code


**Code/Quality Assurance Only** 

- Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance**
- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
