### PR TITLE
Removing  multiple like from a user on comment and multiple unfollow

### DIFF
--- a/routes/postRoutes.js
+++ b/routes/postRoutes.js
@@ -382,7 +382,7 @@ exports.deleteComment = (req, res) => {
     });
 };
 exports.likeComment = (req, res) => {
-  Comment.find({ likes: { $in: req.user._id } }, (err, docs) => {
+  Comment.find({$and :[{ _id: req.body.commentId },{ likes: { $in: req.user._id } }]}, (err, docs) => {
     if (err) return res.status(422).json({ error: err });
     else {
       if (docs.length === 0) {


### PR DESCRIPTION
### Fixes #37 

### Description
now user can like a comment only one time and user can unfollow other user only one time.

**Type of Change:** 
- Code


**Code/Quality Assurance Only**

- Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
